### PR TITLE
Add default GitHub token

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,10 +16,6 @@ Create a workflow `.yml` file in your `.github/workflows` directory.
 An [example workflow](#example) is available below.
 For more information, reference the GitHub Help Documentation for [Creating a workflow file](https://help.github.com/en/articles/configuring-a-workflow#creating-a-workflow-file).
 
-### Inputs
-
-- `github_token`: GitHub Token to use GitHub APIs. You do not need to create your own token, set the token provided by Actions for this.
-
 ## Example
 
 ```yml
@@ -36,8 +32,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: nowactions/update-majorver@v1
-        with:
-          github_token: ${{ secrets. GITHUB_TOKEN }}
 ```
 
 ## Development

--- a/action.yml
+++ b/action.yml
@@ -4,7 +4,7 @@ author: nownabe
 inputs:
   github_token:
     description: GitHub token
-    required: true
+    default: ${{ github.token }}
 runs:
   using: node12
   main: dist/index.js


### PR DESCRIPTION
Actions can provide a default GitHub token so users aren't required to explicitly set it themselves.  This is the technique used by the GitHub built actions like checkout or stale.

- https://github.com/actions/checkout/blob/main/action.yml#L24
- https://github.com/actions/stale/blob/main/action.yml#L5-L8