### PR TITLE
Update action to use node 16

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -6,7 +6,7 @@ inputs:
     description: GitHub token
     default: ${{ github.token }}
 runs:
-  using: node12
+  using: node16
   main: dist/index.js
 branding:
   icon: tag


### PR DESCRIPTION
Node 12 is deprecated on GitHub runners. Because of that we should update this action to use Node 16 instead.

As this is a breaking change the  major version should be bumped to v2.

This implements #252