### PR TITLE
Use node20

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -6,7 +6,7 @@ inputs:
     description: GitHub token
     default: ${{ github.token }}
 runs:
-  using: node16
+  using: node20
   main: dist/index.js
 branding:
   icon: tag


### PR DESCRIPTION
> Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: nowactions/update-majorver@v1.

## Related issues

- #252
- #254